### PR TITLE
OS agnostic join logic for bakefile_path

### DIFF
--- a/addon/utility/gui/Viewport.py
+++ b/addon/utility/gui/Viewport.py
@@ -7,7 +7,7 @@ class ViewportDraw:
 
         bakefile = "TLM_Overlay.png"
         scriptDir = os.path.dirname(os.path.realpath(__file__))
-        bakefile_path = os.path.abspath(os.path.join(scriptDir, '..', '..', 'assets/' + bakefile))
+        bakefile_path = os.path.abspath(os.path.join(scriptDir, '..', '..', 'assets', bakefile))
 
         image_name = "TLM_Overlay.png"
 


### PR DESCRIPTION
Small update ensures OS agnostic path join between `assets/` and `bakefile` components of the values stored in `bakefile_path`