### PR TITLE
Support Blender 4.2 Light probes

### DIFF
--- a/addon/operators/tlm.py
+++ b/addon/operators/tlm.py
@@ -737,7 +737,7 @@ class TLM_BuildEnvironmentProbes(bpy.types.Operator):
         for obj in bpy.context.scene.objects:
 
             if obj.type == "LIGHT_PROBE":
-                if obj.data.type == "CUBEMAP":
+                if obj.data.type == "SPHERE":
 
                     cam_name = "EnvPCam_" + obj.name
                     camera = bpy.data.cameras.new(cam_name)

--- a/addon/properties/scene.py
+++ b/addon/properties/scene.py
@@ -489,11 +489,11 @@ class TLM_SceneProperties(bpy.types.PropertyGroup):
                 default='256')
 
     tlm_environment_probe_engine : EnumProperty(
-        items = [('BLENDER_EEVEE', 'Eevee', 'TODO'),
+        items = [('BLENDER_EEVEE_NEXT', 'Eevee', 'TODO'),
                  ('CYCLES', 'Cycles', 'TODO')],
                 name = "Probe Render Engine", 
                 description="TODO", 
-                default='BLENDER_EEVEE')
+                default='BLENDER_EEVEE_NEXT')
 
     tlm_load_folder : StringProperty(
         name="Load Folder",


### PR DESCRIPTION
Fixes environment probes not working in Blender 4.2 (`CUBEMAP` light probes were replaced with `SPHERE` light probes)

Fixes `Eevee` target when baking environment probes